### PR TITLE
Use builtin find

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var arrayFindIndex = require('array-find-index')
 var parse = require('spdx-expression-parse')
 
 var ranges = require('spdx-ranges')
@@ -17,12 +16,12 @@ var rangeComparison = function (comparison) {
     }
     return ranges.some(function (range) {
       var firstLicense = firstAST.license
-      var indexOfFirst = arrayFindIndex(range, function (element) {
+      const indexOfFirst = range.findIndex((element) => {
         return (
           element === firstLicense ||
           (
             Array.isArray(element) &&
-            element.indexOf(firstLicense) !== -1
+            element.includes(firstLicense)
           )
         )
       })
@@ -30,15 +29,13 @@ var rangeComparison = function (comparison) {
         return false
       }
       var secondLicense = secondAST.license
-      var indexOfSecond = arrayFindIndex(range, function (element) {
-        return (
-          element === secondLicense ||
-          (
-            Array.isArray(element) &&
-            element.indexOf(secondLicense) !== -1
-          )
+      const indexOfSecond = range.findIndex((element) =>
+        element === secondLicense ||
+        (
+          Array.isArray(element) &&
+          element.includes(secondLicense)
         )
-      })
+      )
       if (indexOfSecond < 0) {
         return false
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "dependencies": {
-    "array-find-index": "^1.0.2",
     "spdx-expression-parse": "^3.0.0",
     "spdx-ranges": "^2.0.0"
   },


### PR DESCRIPTION
The package `array-find-index` is abandoned and obsolete. This change switches it out for the built-in `Array.findIndex`.

It's [built-in as of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex#browser_compatibility): 
 - Node.js v4
 - Chrome v45
 - Firefox v25
 - Safari v8 

Also fixes an issue where the final test breaks on nodejs versions v10 and above.


Tests run locally with Node.js v10.24.1.